### PR TITLE
OpenGraph support on twitter

### DIFF
--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -210,6 +210,83 @@ export async function GET(request: Request) {
   const pfpUrl =
     searchParams.get("pfpUrl") || "https://i.ibb.co/QvFx17r6/logo.png";
 
+  // Check if this is a request for HTML (Twitter crawler) or image
+  const userAgent = request.headers.get("user-agent") || "";
+  const isTwitterBot =
+    userAgent.includes("Twitterbot") ||
+    userAgent.includes("facebookexternalhit");
+
+  if (isTwitterBot) {
+    // Return HTML with OpenGraph meta tags for Twitter crawler
+    const ogImageUrl = `${request.url}`;
+    const html = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>MoonXBT Airdrop - Join the @moonXBT_ai airdrop!</title>
+  <meta name="description" content="🚀 Join the @moonXBT_ai airdrop! Complete tasks to earn your share of tokens 🌙✨">
+  
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="${request.url}">
+  <meta property="og:title" content="MoonXBT Airdrop - Join the @moonXBT_ai airdrop!">
+  <meta property="og:description" content="🚀 Join the @moonXBT_ai airdrop! Complete tasks to earn your share of tokens 🌙✨">
+  <meta property="og:image" content="${ogImageUrl}">
+  <meta property="og:image:width" content="1500">
+  <meta property="og:image:height" content="1000">
+  <meta property="og:image:alt" content="MoonXBT Airdrop - ${points} points earned">
+  
+  <!-- Twitter -->
+  <meta property="twitter:card" content="summary_large_image">
+  <meta property="twitter:url" content="${request.url}">
+  <meta property="twitter:title" content="MoonXBT Airdrop - Join the @moonXBT_ai airdrop!">
+  <meta property="twitter:description" content="🚀 Join the @moonXBT_ai airdrop! Complete tasks to earn your share of tokens 🌙✨">
+  <meta property="twitter:image" content="${ogImageUrl}">
+  <meta property="twitter:image:alt" content="MoonXBT Airdrop - ${points} points earned">
+  
+  <style>
+    body { 
+      font-family: system-ui, -apple-system, sans-serif; 
+      margin: 0; 
+      padding: 20px; 
+      background: #1a1a2e;
+      color: white;
+      text-align: center;
+    }
+    .container { max-width: 600px; margin: 0 auto; }
+    h1 { color: #fff; margin-bottom: 20px; }
+    p { color: #ccc; line-height: 1.6; }
+    .cta { 
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 15px 30px;
+      border-radius: 25px;
+      text-decoration: none;
+      display: inline-block;
+      margin-top: 20px;
+      font-weight: bold;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>🚀 MoonXBT Airdrop</h1>
+    <p>Join the @moonXBT_ai airdrop! Complete tasks to earn your share of tokens 🌙✨</p>
+    <p>You've earned <strong>${points} points</strong> so far!</p>
+    <a href="https://moonxbt.fun" class="cta">Join the Airdrop</a>
+  </div>
+</body>
+</html>`;
+
+    return new Response(html, {
+      headers: {
+        "Content-Type": "text/html",
+        "Cache-Control": "public, max-age=3600",
+      },
+    });
+  }
+
   // Get relevant avatars only for Farcaster shares
   const avatars = await getRelevantFollowers(moonxbtFid, Number(viewerFid));
 

--- a/src/hooks/useAirdropTasks.tsx
+++ b/src/hooks/useAirdropTasks.tsx
@@ -328,7 +328,7 @@ export const useAirdropTasks = (isInMiniApp: boolean = true) => {
           url: isInMiniApp
             ? undefined
             : `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-                "🚀 Join the @moonXBT_ai airdrop! Complete tasks to earn your share of tokens 🌙✨\n\n#moonXBT #Airdrop #Crypto https://moonxbt.fun \n\n"
+                "🚀 Join the @moonXBT_ai airdrop! Complete tasks to earn your share of tokens 🌙✨\n\n#moonXBT #Airdrop #Crypto\n\n"
               )}`,
           icon: isInMiniApp ? (
             <MessageCircle className="w-4 h-4 text-purple-500" />


### PR DESCRIPTION
Improvements to social sharing and OpenGraph support for the MoonXBT Airdrop app. The most significant change is the addition of logic to serve custom HTML with OpenGraph and Twitter meta tags for social crawlers, ensuring better link previews when shared on platforms like Twitter and Facebook. Additionally, the default tweet text for sharing the airdrop has been updated for clarity.

**Social sharing and OpenGraph enhancements:**

* Added detection of Twitter and Facebook crawlers in `src/app/api/og/route.tsx`, and now serve a custom HTML page with OpenGraph and Twitter meta tags to improve link previews for social sharing.

**User experience improvements:**

* Updated the default tweet text in `src/hooks/useAirdropTasks.tsx` for sharing the airdrop, removing the direct link from the tweet and making the message clearer.